### PR TITLE
Fixed: nextScheduledAtDate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build*
+.idea

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,10 +1,14 @@
 {
   "dependencies": {
     "later": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/later/-/later-1.1.6.tgz",
+      "from": "later@1.1.6"
     },
     "timezone": {
-      "version": "0.0.41"
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/timezone/-/timezone-0.0.41.tgz",
+      "from": "timezone@0.0.41"
     }
   }
 }

--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@ Package.describe({
   git: 'https://github.com/thesaucecode/meteor-synced-cron.git'
 });
 
-Npm.depends({later: '1.1.6', timezone:'0.0.41'});
+Npm.depends({later: '1.1.6', timezone:'1.0.6'});
 
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.1.1');

--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@ Package.describe({
   git: 'https://github.com/thesaucecode/meteor-synced-cron.git'
 });
 
-Npm.depends({later: '1.1.6', timezone:'1.0.6'});
+Npm.depends({later: '1.2.0', timezone:'1.0.6'});
 
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.1.1');

--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -228,6 +228,35 @@ SyncedCron.nextScheduledAtDate = function(jobName) {
     new Date(schedule.next(2).pop().getTime() + scheduleOffset);
 }
 
+// SyncedCron.nearestScheduledAtDate({
+//   timezone: String,
+//   schedule: Function,
+//   context: Object,
+//   startedAt: Date | undefined
+//   scheduleOffset: Number | undefined
+// })
+SyncedCron.nearestScheduledAtDate = function(options) {
+  check(options.timezone, String);
+  check(options.schedule, Function);
+
+  if (!!options.startedAt)
+    check(options.startedAt, Date);
+
+  if (!!options.scheduleOffset)
+    check(options.scheduleOffset, Number);
+
+  const timezone = typeof options.timezone === 'string' || typeof options.timezone === 'function' ? options.timezone : null;
+  const scheduleOffset = options.scheduleOffset || 0;
+  const scheduleContext = typeof options.context === 'object' ? options.context : {};
+  const schedule = options.schedule.call(scheduleContext, Later.parse);
+
+  this._setTimezone(timezone);
+
+  return !!options.startedAt ?
+    new Date(Later.schedule(schedule).next(1, options.startedAt).getTime() + scheduleOffset) :
+    new Date(Later.schedule(schedule).next(1).getTime() + scheduleOffset);
+}
+
 // Remove and stop the entry referenced by jobName
 SyncedCron.remove = function(jobName) {
   var entry = this._entries[jobName];

--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -224,8 +224,8 @@ SyncedCron.nextScheduledAtDate = function(jobName) {
   var startedAt = entry.startedAt;
 
   return !!startedAt ?
-    new Date(schedule.next(1, startedAt).getTime() + scheduleOffset) :
-    new Date(schedule.next(1).getTime() + scheduleOffset);
+    new Date(schedule.next(2, startedAt).pop().getTime() + scheduleOffset) :
+    new Date(schedule.next(2).pop().getTime() + scheduleOffset);
 }
 
 // Remove and stop the entry referenced by jobName

--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -209,7 +209,8 @@ SyncedCron.nextScheduledAtDate = function(jobName) {
 
   if (entry)
     this._setTimezone(entry.timezone, entry);
-  return new Date(Later.schedule(entry.schedule(Later.parse)).next(1).getTime() + scheduleOffset);
+
+  return new Date(Later.schedule(entry.schedule.call(entry.context, Later.parse)).next(2).pop().getTime() + scheduleOffset);
 }
 
 // Remove and stop the entry referenced by jobName

--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -204,13 +204,15 @@ SyncedCron.start = function() {
 
 // Return the next scheduled date of the first matching entry or undefined
 SyncedCron.nextScheduledAtDate = function(jobName) {
-  var entry = this._entries[jobName];
+  var entry = this._entries[jobName];  
+  
+  if (!entry)
+    return undefined;
+    
   var scheduleOffset = entry.scheduleOffset || 0;
-
-  if (entry)
-    this._setTimezone(entry.timezone, entry);
-
-  return new Date(Later.schedule(entry.schedule.call(entry.context, Later.parse)).next(2).pop().getTime() + scheduleOffset);
+  this._setTimezone(entry.timezone, entry);
+  
+  return new Date(Later.schedule(entry.schedule.call(entry.context, Later.parse)).next(1).getTime() + scheduleOffset);
 }
 
 // Remove and stop the entry referenced by jobName

--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -389,9 +389,10 @@ SyncedCron._laterSetTimeout = function(fn, sched, timezone, scheduleOffset, star
     if (timezone && typeof timezone === 'string') {
       SyncedCron._setTimezone(timezone);
     }
-
-    var now = (!!startedAt && startedAt.valueOf() > Date.now() ? startedAt.valueOf() : Date.now()) - scheduleOffset,
-        next = s.next(2, now),
+    
+    var _startedAt = (!!startedAt && startedAt.valueOf() > Date.now() ? startedAt.valueOf() : Date.now()) - scheduleOffset,
+        now = Date.now(),
+        next = s.next(2, _startedAt),
         diff = next[0].getTime() - now,
         intendedAt = next[0];
 


### PR DESCRIPTION
**Several bugs in SyncedCron.nextScheduledAtDate function**

1.Should call `entry.schedule` with `entry.context` context. 

``` js
SyncedCron.add({
  name: reportId,
  timezone: report.timezone,
  context: {
    report
  },
  schedule(parser: Later.IParseStatic): IScheduleData {
    let schedule: IScheduleData = parser.text( this.report.schedule); // <-- error here, context doesn't contain *report*
    // ...
    return schedule;
  },
  job() {
    // ...
  }
});
```

2.`Later.schedule(..).next(1)` returns current date, because that called in the same time. `Later.schedule(..).next(2)` returns array: first element is current date, second - next date.
