### PR TITLE
check of only error code instead of name and code.

### DIFF
--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -279,7 +279,7 @@ SyncedCron._entryWrapper = function(entry) {
     } catch (e) {
       // http://www.mongodb.org/about/contributors/error-codes/
       // 11000 == duplicate key error
-      if (e.name === 'MongoError' && e.code === 11000) {
+      if (e.code === 11000) {
         log.info('Not running "' + entry.name + '" again.');
         return;
       }


### PR DESCRIPTION
as per the thread here: [Issue](https://github.com/percolatestudio/meteor-synced-cron/issues/134)

Meteor 1.7 having switched from v2 of the node mongo driver to v3.

when an .insert() call results in a duplicate key error, the error's name has changed from MongoError to BulkWriteError. So changing the condition will work for both the case.

Please get back to me if any further help required.
